### PR TITLE
downgrade get_data response code logging from INFO to DEBUG

### DIFF
--- a/hole/__init__.py
+++ b/hole/__init__.py
@@ -45,7 +45,7 @@ class Hole(object):
             async with async_timeout.timeout(5, loop=self._loop):
                 response = await self._session.get(self.base_url)
 
-            _LOGGER.info("Response from *hole: %s", response.status)
+            _LOGGER.debug("Response from *hole: %s", response.status)
             self.data = await response.json()
             _LOGGER.debug(self.data)
 


### PR DESCRIPTION
As per https://github.com/home-assistant/core/issues/33151

We feel that logging INFO for "Response Code" is a bit too spammy.  That is, at least for the home assistant usage.  However this is merely _one_ consumer of the library.